### PR TITLE
update ISR::Product don't compare against $args{selected} if it is undef

### DIFF
--- a/lib/Interchange6/Schema/Result/Product.pm
+++ b/lib/Interchange6/Schema/Result/Product.pm
@@ -345,7 +345,7 @@ sub attribute_iterator {
             }
 
             # determined whether this is the current attribute
-            if ($prod_att->sku eq $args{selected}) {
+            if ($args{selected} && $prod_att->sku eq $args{selected}) {
                 $att_record->{value_map}->{$attr_value{value}}->{selected} = 1;
             }
         }


### PR DESCRIPTION
Small patch to attribute_iterator which removes warnings when $args{selected} is undef when used in eq
