### PR TITLE
Fix database definition errors in MySQL

### DIFF
--- a/lib/Interchange6/Schema/Result/Product.pm
+++ b/lib/Interchange6/Schema/Result/Product.pm
@@ -188,9 +188,9 @@ __PACKAGE__->add_columns(
   "inventory_exempt",
   { data_type => "boolean", default_value => \"false", is_nullable => 0 },
   "created",
-  { data_type => "datetime", set_on_create => 1, is_nullable => 0 },
+  { data_type => "datetime", set_on_create => 1, is_nullable => 0, default_value => \'now()' },
   "last_modified",
-  { data_type => "datetime", set_on_create => 1, set_on_update => 1, is_nullable => 0 },
+  { data_type => "datetime", set_on_create => 1, set_on_update => 1, is_nullable => 0, default_value => \'now()' },
 );
 
 =head1 METHODS


### PR DESCRIPTION
Hello,

I was attempting to run the Flowers application and ran into some trouble initialising the database.

The first commit fixes errors like this:
`ERROR 1101 (42000) at line 49: BLOB/TEXT column 'type' can't have a default value`
when importing the _sql/Interchange6-Schema-0.013-MySQL.sql_ file into MySQL 5.6.15;

The second commit fixes `Flowers/bin/populate` errors like this:
`DBIx::Class::Storage::DBI::_dbh_execute_for_fetch(): execute_for_fetch() aborted with 'Field 'created' doesn't have a default value' at populate slice:
{
  canonical_sku => undef,
  description => "Surprise the one who makes you smile, or express yourself perfectly with this stunning...`
