### PR TITLE
add InflateColumn::Boolean to ensure booleans work the same across DBs

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,6 +21,7 @@ WriteMakefile(
     PREREQ_PM => {
                   'DBIx::Class' => 0,
                   'DBIx::Class::EncodedColumn' => 0,
+                  'DBIx::Class::InflateColumn::Boolean' => 0,
                   'DBIx::Class::TimeStamp' => 0,
                   'DBIx::Class::Tree' => 0,
                   'SQL::Translator' => 0.11016,

--- a/lib/Interchange6/Schema/Result/Address.pm
+++ b/lib/Interchange6/Schema/Result/Address.pm
@@ -15,7 +15,7 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
-__PACKAGE__->load_components(qw(TimeStamp));
+__PACKAGE__->load_components(qw(TimeStamp InflateColumn::Boolean));
 
 =head1 TABLE: C<addresses>
 

--- a/lib/Interchange6/Schema/Result/Attribute.pm
+++ b/lib/Interchange6/Schema/Result/Attribute.pm
@@ -12,6 +12,8 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+__PACKAGE__->load_components(qw(InflateColumn::Boolean));
+
 =head1 TABLE: C<attributes>
 
 =cut

--- a/lib/Interchange6/Schema/Result/Cart.pm
+++ b/lib/Interchange6/Schema/Result/Cart.pm
@@ -15,7 +15,7 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
-__PACKAGE__->load_components(qw(TimeStamp));
+__PACKAGE__->load_components(qw(TimeStamp InflateColumn::Boolean));
 
 =head1 TABLE: C<carts>
 

--- a/lib/Interchange6/Schema/Result/Country.pm
+++ b/lib/Interchange6/Schema/Result/Country.pm
@@ -15,6 +15,8 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+__PACKAGE__->load_components(qw(InflateColumn::Boolean));
+
 =head1 TABLE: C<countries>
 
 =cut

--- a/lib/Interchange6/Schema/Result/Media.pm
+++ b/lib/Interchange6/Schema/Result/Media.pm
@@ -15,7 +15,7 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
-__PACKAGE__->load_components(qw(TimeStamp));
+__PACKAGE__->load_components(qw(TimeStamp InflateColumn::Boolean));
 
 =head1 TABLE: C<media>
 

--- a/lib/Interchange6/Schema/Result/Navigation.pm
+++ b/lib/Interchange6/Schema/Result/Navigation.pm
@@ -15,6 +15,8 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+__PACKAGE__->load_components(qw(InflateColumn::Boolean));
+
 =head1 TABLE: C<navigation>
 
 =cut

--- a/lib/Interchange6/Schema/Result/Product.pm
+++ b/lib/Interchange6/Schema/Result/Product.pm
@@ -15,7 +15,7 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
-__PACKAGE__->load_components(qw(TimeStamp));
+__PACKAGE__->load_components(qw(TimeStamp InflateColumn::Boolean));
 
 =head1 TABLE: C<products>
 

--- a/lib/Interchange6/Schema/Result/ProductAttribute.pm
+++ b/lib/Interchange6/Schema/Result/ProductAttribute.pm
@@ -15,6 +15,8 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+__PACKAGE__->load_components(qw(InflateColumn::Boolean));
+
 =head1 TABLE: C<product_attributes>
 
 =cut

--- a/lib/Interchange6/Schema/Result/Review.pm
+++ b/lib/Interchange6/Schema/Result/Review.pm
@@ -15,7 +15,7 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
-__PACKAGE__->load_components(qw(TimeStamp));
+__PACKAGE__->load_components(qw(TimeStamp InflateColumn::Boolean));
 
 =head1 TABLE: C<reviews>
 

--- a/lib/Interchange6/Schema/Result/State.pm
+++ b/lib/Interchange6/Schema/Result/State.pm
@@ -15,6 +15,8 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
+__PACKAGE__->load_components(qw(InflateColumn::Boolean));
+
 =head1 TABLE: C<states>
 
 =cut

--- a/lib/Interchange6/Schema/Result/User.pm
+++ b/lib/Interchange6/Schema/Result/User.pm
@@ -15,7 +15,7 @@ use warnings;
 
 use base 'DBIx::Class::Core';
 
-__PACKAGE__->load_components(qw(FilterColumn EncodedColumn TimeStamp));
+__PACKAGE__->load_components(qw(FilterColumn EncodedColumn TimeStamp InflateColumn::Boolean));
 
 =head1 TABLE: C<users>
 


### PR DESCRIPTION
Not sure whether it is better to go down this route or whether we should change all booleans to have default values of 1/0 instead of true/false. We need to do something or otherwise sqlite cannot be used with DPIC6.
