### PR TITLE
change password encrytpion to bcrypt

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,6 +25,7 @@ WriteMakefile(
                        'Try::Tiny' => 0,
                       },
     PREREQ_PM => {
+                  'Crypt::Eksblowfish::Bcrypt' => 0,
                   'DBIx::Class' => 0,
                   'DBIx::Class::EncodedColumn' => 0,
                   'DBIx::Class::InflateColumn::DateTime' => 0,

--- a/lib/Interchange6/Schema/Result/User.pm
+++ b/lib/Interchange6/Schema/Result/User.pm
@@ -61,10 +61,10 @@ nickname is automatically converted to lowercase
   data_type: 'varchar'
   default_value: (empty string)
   is_nullable: 0
-  size: 255
+  size: 60
   encode_column: 1
-  encode_class: 'Digest'
-  encode_args: { algorithm => 'SHA-512', format => 'hex', salt_length => 10 }
+  encode_class: 'Crypt::Eksblowfish::Bcrypt'
+  encode_args: { key_nul => 1, cost => 14 }
   encode_check_method: 'check_password'
 
 =head2 first_name
@@ -126,10 +126,10 @@ __PACKAGE__->add_columns(
    data_type           => "varchar",
    default_value       => "",
    is_nullable         => 0,
-   size                => 255, 
+   size                => 60, 
    encode_column       => 1,
-   encode_class        => 'Digest',
-   encode_args         => { algorithm => 'SHA-512', format => 'hex', salt_length => 10 },
+   encode_class        => 'Crypt::Eksblowfish::Bcrypt',
+   encode_args         => { key_nul => 1, cost => 14 },
    encode_check_method => 'check_password',
 },
   "first_name",

--- a/t/dbic_testdatabase.t
+++ b/t/dbic_testdatabase.t
@@ -2,8 +2,7 @@ use strict;
 use warnings;
 
 use Data::Dumper;
-#use Test::Most 'die',  tests => 35;
-use Test::Most 'die';
+use Test::Most 'die',  tests => 38;
 
 use Try::Tiny;
 use Interchange6::Schema;
@@ -136,6 +135,7 @@ ok($user->id == 1, "Testing user id.")
 my $pwd = $user->password;
 
 ok($pwd ne 'nevairbe', 'Test password encryption');
+like($pwd, qr/^\$2a\$14\$.{53}$/, "Check password hash has correct format");
 
 # check that username is unique
 my $dup_error;
@@ -247,5 +247,3 @@ isa_ok($address, 'Interchange6::Schema::Result::Address')
 
 ok($address->id == 1, "Testing address id.")
     || diag "Address id: " . $address->id;
-
-done_testing;


### PR DESCRIPTION
This patch is only really relevant in the case that a system has been compromised and database content stolen. It shows that the site administrators took security seriously and have made cracking the password database as difficult as reasonably possible. We don't want users of our code to look like idiots - something that would only reflect badly on developers.
