### PR TITLE
add Component::Validation and rewrite Tax to use it

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -2,6 +2,7 @@ bin/interchange6-create-database
 CHANGES
 lib/Interchange6/Schema.pm
 lib/Interchange6/Schema/Base/Attribute.pm
+lib/Interchange6/Schema/Component/Validation.pm
 lib/Interchange6/Schema/Populate/CountryLocale.pm
 lib/Interchange6/Schema/Populate/StateLocale.pm
 lib/Interchange6/Schema/Result/Address.pm

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -27,7 +27,6 @@ WriteMakefile(
                   'DBIx::Class' => 0,
                   'DBIx::Class::EncodedColumn' => 0,
                   'DBIx::Class::InflateColumn::DateTime' => 0,
-                  'DBIx::Class::Result::Validation' => 0,
                   'DBIx::Class::TimeStamp' => 0,
                   'DBIx::Class::Tree' => 0,
                   'MooX::HandlesVia' => 0.001005,

--- a/lib/Interchange6/Schema/Component/Validation.pm
+++ b/lib/Interchange6/Schema/Component/Validation.pm
@@ -1,0 +1,81 @@
+use utf8;
+
+package Interchange6::Schema::Component::Validation;
+
+=head1 NAME
+
+Interchange6::Schema::Component::Validation
+
+=head1 SYNOPSIS
+
+  package My::Result;
+
+  __PACKAGE__->load_components(qw(
+    +Interchange6::Schema::Component::Validation
+  ));
+
+  sub validate {
+    my $self = shift;
+    my $schema = $self->result_source->schema;
+
+    unless ( $self->some_column =~ /magic/ ) {
+      $schema->throw_exception("some_column does not contain magic");
+    }
+  }
+
+=head1 DESCRIPTION
+
+This component allows validation of row attributes to be deferred until other components in the stack have been called. For example you might want to have the TimeStamp component called before validation so that datetime columns with set_on_create are defined before validation occurs. In this case your local_components call might look like;
+
+__PACKAGE__->load_components(
+    qw(TimeStamp +Interchange6::Schema::Component::Validation)
+);
+
+In order to fail validation the L</validation> method must throw an exception.
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'DBIx::Class';
+
+=head1 METHODS
+
+=head2 validate
+
+Called before insert or update action. Method should be overloaded by class which load this component. Validation failures should result in L<DBIx::Class::Schema::throw_exception|DBIx::Class::Schema/throw_exception> being called.
+
+=cut
+
+sub validate {
+    my $self = shift;
+}
+
+=head2 insert
+
+Overload insert to call L</validate> before insert is performed.
+
+=cut
+
+sub insert {
+    my ( $self, @args ) = @_;
+    $self->validate;
+    $self->next::method(@args);
+    return $self;
+}
+
+=head2 update
+
+Overload update to call L</validate> before update is performed.
+
+=cut
+
+sub update {
+    my ( $self, @args ) = @_;
+    $self->validate;
+    $self->next::method(@args);
+    return $self;
+}
+
+1;

--- a/t/tax.t
+++ b/t/tax.t
@@ -179,7 +179,14 @@ foreach my $code ( sort keys %data ) {
 
 # test some incorrect tax entries
 
-$data->{country_iso_code} = 'FooBar';
+$data = {
+    tax_name         => 'IE VAT Standard',
+    description      => 'Ireland VAT Standard Rate',
+    country_iso_code => 'FooBar',
+    percent          => 21,
+    valid_from       => '2010-01-01',
+    valid_to         => '2011-12-31'
+};
 throws_ok(
     sub { $rsettax->create($data) },
     qr/iso_code not valid/,


### PR DESCRIPTION
Moose dependency gone.
Component::Validation is incredibly simple and exists purely so that validation can occur at the position in the component stack that you choose.
