### PR TITLE
add Populate::Zone + trim US states in Populate::StateLocale

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -5,6 +5,7 @@ lib/Interchange6/Schema/Base/Attribute.pm
 lib/Interchange6/Schema/Component/Validation.pm
 lib/Interchange6/Schema/Populate/CountryLocale.pm
 lib/Interchange6/Schema/Populate/StateLocale.pm
+lib/Interchange6/Schema/Populate/Zone.pm
 lib/Interchange6/Schema/Result/Address.pm
 lib/Interchange6/Schema/Result/Attribute.pm
 lib/Interchange6/Schema/Result/AttributeValue.pm

--- a/lib/Interchange6/Schema/Populate/StateLocale.pm
+++ b/lib/Interchange6/Schema/Populate/StateLocale.pm
@@ -17,6 +17,30 @@ use Moo;
 use Interchange6::Schema::Populate::CountryLocale;
 use Locale::SubCountry;
 
+=head1 ATTRIBUTES
+
+=head2 generate_states_id
+
+Boolean specifiying whether the L</records> method should add states_id. Defaults to 0.
+
+=cut
+
+has generate_states_id => (
+    is      => 'ro',
+    default => 0,
+);
+
+=head2 states_id_initial_value
+
+The initial value of the states_id sequence (only used if generate_states_id is 1). Default is 1.
+
+=cut
+
+has states_id_initial_value => (
+    is      => 'ro',
+    default => 1,
+);
+
 =head1 METHODS
 
 =head2 records
@@ -27,24 +51,51 @@ ready to use with populate schema method.
 =cut
 
 sub records {
+    my $self      = shift;
+    my $states_id = $self->states_id_initial_value;
+
     my @states;
     my $countries = Interchange6::Schema::Populate::CountryLocale->new->records;
 
     for my $country_object (@$countries) {
-        if ($country_object->{'show_states'} == 1){
-        my $country_code = $country_object->{'country_iso_code'};
-        my $country = new Locale::SubCountry( $country_object->{'country_iso_code'} );
-        my %country_states_keyed_by_code = $country->code_full_name_hash;
+        if ( $country_object->{'show_states'} == 1 ) {
+            my $country_code = $country_object->{'country_iso_code'};
+            my $country =
+              new Locale::SubCountry( $country_object->{'country_iso_code'} );
+            my %country_states_keyed_by_code = $country->code_full_name_hash;
 
-            foreach my $state_code ( sort keys %country_states_keyed_by_code ){
+            foreach my $state_code ( sort keys %country_states_keyed_by_code ) {
+
+                # some US 'states' are not actually states of the US
+                next
+                  if ( $country_code eq 'US'
+                    && $state_code =~ /(AS|GU|MP|PR|UM|VI)/ );
+
                 my $state_name = $country_states_keyed_by_code{$state_code};
+
                 # remove (Junk) from some records
                 $state_name =~ s/\s*\([^)]*\)//g;
-                push @states, {'name' => $state_name, 'state_iso_code' => $state_code, 'country_iso_code' => $country_code};
+                if ( $self->generate_states_id == 1 ) {
+                    push @states,
+                      {
+                        'states_id'        => $states_id++,
+                        'name'             => $state_name,
+                        'state_iso_code'   => $state_code,
+                        'country_iso_code' => $country_code
+                      };
+                }
+                else {
+                    push @states,
+                      {
+                        'name'             => $state_name,
+                        'state_iso_code'   => $state_code,
+                        'country_iso_code' => $country_code
+                      };
+                }
             }
         }
     }
-    
+
     return \@states;
 }
 

--- a/lib/Interchange6/Schema/Populate/Zone.pm
+++ b/lib/Interchange6/Schema/Populate/Zone.pm
@@ -1,0 +1,110 @@
+package Interchange6::Schema::Populate::Zone;
+
+=head1 NAME
+
+Interchange6::Schema::Populate::Zone
+
+=head1 DESCRIPTION
+
+This module provides population capabilities for the Zone schema
+
+=cut
+
+use strict;
+use warnings;
+
+use Moo;
+use Interchange6::Schema::Populate::CountryLocale;
+use Interchange6::Schema::Populate::StateLocale;
+
+=head1 METHODS
+
+=head2 records
+
+Returns array reference containing one hash reference per zone ready to use with populate schema method.
+
+=cut
+
+sub records {
+    my ( @zones, %states_by_country );
+
+    my $countries = Interchange6::Schema::Populate::CountryLocale->new->records;
+
+    my $states = Interchange6::Schema::Populate::StateLocale->new(
+        { generate_states_id => 1 } )->records;
+
+    foreach my $state (@$states) {
+        $states_by_country{ $state->{country_iso_code} }
+          { $state->{state_iso_code} } = $state;
+    }
+
+    # one zone per country
+
+    foreach my $country (@$countries) {
+
+        my $country_name = $country->{'name'};
+        my $country_code = $country->{'country_iso_code'};
+
+        push @zones,
+          {
+            zone        => $country_name,
+            ZoneCountry => [ { country_iso_code => $country_code } ],
+          };
+
+        # one zone per state
+
+        if ( exists $states_by_country{$country_code} ) {
+
+            foreach
+              my $state_code ( keys %{ $states_by_country{$country_code} } )
+            {
+
+                my $state = $states_by_country{$country_code}{$state_code};
+
+                my $zone = $country_name . " - " . $state->{'name'};
+
+                push @zones,
+                  {
+                    zone        => $zone,
+                    ZoneCountry => [ { country_iso_code => $country_code } ],
+                    ZoneState   => [ { states_id => $state->{'states_id'} } ],
+                  };
+            }
+        }
+    }
+
+    # US lower 48 includes all 51 from US except for Alaska and Hawaii
+    push @zones,
+      {
+        zone        => 'US lower 48',
+        ZoneCountry => [ { country_iso_code => 'US' } ],
+        ZoneState   => [
+            map { { 'states_id' => $states_by_country{US}{$_}->{'states_id'} } }
+            grep { !/(AK|HI)/ } keys %{ $states_by_country{US} }
+        ],
+      };
+
+    # EU member states
+    push @zones, {
+        zone        => 'EU member states',
+        ZoneCountry => [
+            map { { 'country_iso_code' => $_ } }
+              qw ( BE BG CZ DK DE EE GR ES FR HR IE IT CY LV LT LU HU MT
+              NL AT PL PT RO SI SK FI SE GB )
+        ],
+    };
+
+    # EU VAT countries = EU + Isle of Man
+    push @zones, {
+        zone        => 'EU VAT countries',
+        ZoneCountry => [
+            map { { 'country_iso_code' => $_ } }
+              qw ( BE BG CZ DK DE EE GR ES FR HR IE IT CY LV LT LU HU MT
+              NL AT PL PT RO SI SK FI SE GB IM )
+        ],
+    };
+
+    return \@zones;
+}
+
+1;


### PR DESCRIPTION
Populate::StateLocale can now optionally generate states_id fields that are needed by Populate::Zone.
Zone test have changed considerably.
