### PR TITLE
add t/schema_sanity.t for basic schema sanity testing + Result fixups

### DIFF
--- a/lib/Interchange6/Schema/Result/Attribute.pm
+++ b/lib/Interchange6/Schema/Result/Attribute.pm
@@ -32,6 +32,7 @@ Attribute name, e.g. color or size.
 
   data_type: 'varchar'
   is_nullable: 0
+  size: 255
 
 =head2 type
 
@@ -75,7 +76,7 @@ __PACKAGE__->add_columns(
     is_nullable       => 0,
   },
   "name",
-  { data_type => "varchar", is_nullable => 0},
+  { data_type => "varchar", is_nullable => 0, size => 255 },
   "type",
   { data_type => "text", default_value => "", is_nullable => 0 },
   "title",

--- a/lib/Interchange6/Schema/Result/AttributeValue.pm
+++ b/lib/Interchange6/Schema/Result/AttributeValue.pm
@@ -38,6 +38,7 @@ Value name, e.g. red or white.
 
   data_type: 'varchar'
   is_nullable: 0
+  size: 255
 
 =head2 title
 
@@ -46,6 +47,7 @@ Displayed title for attribute value, e.g. Red or White.
   data_type: 'varchar'
   default_value: (empty string)
   is_nullable: 0
+  size: 255
 
 =head2 priority
 
@@ -67,9 +69,9 @@ __PACKAGE__->add_columns(
   "attributes_id",
   { data_type => "integer", is_foreign_key => 1, is_nullable => 0},
   "value",
-  { data_type => "varchar", is_nullable => 0},
+  { data_type => "varchar", is_nullable => 0, size => 255 },
   "title",
-  { data_type => "varchar", default_value => "", is_nullable => 0 },
+  { data_type => "varchar", default_value => "", is_nullable => 0, size => 255 },
   "priority",
   { data_type => "integer", default_value => 0, is_nullable => 0 },
 );

--- a/t/etc/schema.pl
+++ b/t/etc/schema.pl
@@ -1,0 +1,3 @@
+{
+    'schema_class' => 'Interchange6::Schema',
+};

--- a/t/schema_sanity.t
+++ b/t/schema_sanity.t
@@ -1,0 +1,122 @@
+use strict;
+use warnings;
+
+use Test::Most;
+
+unless ( $ENV{RELEASE_TESTING} ) {
+    plan( skip_all => "Author tests not required for installation" );
+}
+
+use Data::Dumper;
+
+use Test::DBIx::Class;
+
+my $schema = Schema;
+
+foreach my $source_name ( sort $schema->sources ) {
+
+    my $source = $schema->source($source_name);
+
+    my $columns_info = $source->columns_info;
+
+    # check columns
+
+    foreach my $column ( sort keys %$columns_info ) {
+
+        my $data_type = $columns_info->{$column}->{data_type};
+        my $size      = $columns_info->{$column}->{size};
+
+        # created/last_modified
+
+        if ( $column =~ /^(created|last_modified)$/ ) {
+            ok( defined $columns_info->{$column}->{dynamic_default_on_create},
+                "set_on_create exists for $source_name $column" );
+
+            if ( $column eq 'last_modified' ) {
+                ok(
+                    defined $columns_info->{$column}
+                      ->{dynamic_default_on_update},
+                    "set_on_update exists for $source_name $column"
+                );
+            }
+        }
+
+        # auto_increment
+
+        if ( $columns_info->{$column}->{is_auto_increment} ) {
+            ok(
+                defined $data_type && $data_type eq 'integer',
+                "$source_name $column has integer auto_increment col"
+            );
+        }
+
+        # data_type specific checks
+
+        if ( $data_type =~ /^(boolean|integer|text)$/ ) {
+
+            # nothing to see
+        }
+        elsif ( $data_type =~ /^(var)*char$/ ) {
+            ok( defined $size, "size is defined for $source_name $column" )
+              && cmp_ok( $size, '>=', 1, "size >= 1 for $source_name $column" );
+        }
+        elsif ( $data_type eq 'numeric' ) {
+                 ok( defined $size, "size is defined for $source_name $column" )
+              && ok( ref($size) eq 'ARRAY', "and is an array" )
+              && cmp_ok( scalar @$size, '==', 2, "that has 2 elements" )
+              && cmp_ok( $size->[0], '>=', $size->[1],
+                "and precision >= scale" );
+        }
+        elsif ( $data_type =~ /^(date(time)*|timestamp)$/ ) {
+            ok(
+                defined $columns_info->{$column}->{_ic_dt_method},
+                "InflateColumn::DateTime set for $source_name $column"
+            );
+        }
+        else {
+            fail("unexpected data_type $data_type for $source_name $column");
+        }
+
+    }
+
+    # check relationships
+
+    foreach my $relname ( $source->relationships ) {
+
+        my $relationship = $source->relationship_info($relname);
+
+        my $foreign_source_name = $relationship->{source};
+
+        my $foreign_source       = $schema->source($foreign_source_name);
+        my $foreign_columns_info = $foreign_source->columns_info;
+
+        my @cond = %{ $relationship->{cond} };
+
+        my ($self_column)    = grep { s/^self\.// } @cond;
+        my ($foreign_column) = grep { s/^foreign\.// } @cond;
+
+        # check data_types match
+
+        cmp_ok(
+            $columns_info->{$self_column}->{data_type},
+            'eq',
+            $foreign_columns_info->{$foreign_column}->{data_type},
+            "data_type matches across relationship $relname in $source_name"
+        );
+
+        if ( $columns_info->{$self_column}->{data_type} =~ /^(var)*char$/ ) {
+
+            # check sizes match
+
+            cmp_ok(
+                $columns_info->{$self_column}->{size},
+                'eq',
+                $foreign_columns_info->{$foreign_column}->{size},
+                "size matches across relationship $relname in $source_name"
+            );
+
+        }
+    }
+}
+
+done_testing;


### PR DESCRIPTION
Here's the basic schema sanity testing that I promised earlier today. I also fixed up the problems it found in various Result classes. Decided to use Test::DBIx::Class but not added it to BUILD_REQUIRES yet since it is so far only used for RELEASE_TESTING. Will soon use it for other things in IS.
