### PR TITLE
return a sane product path when more than 1 path exists

### DIFF
--- a/t/lib/Test/Navigation.pm
+++ b/t/lib/Test/Navigation.pm
@@ -87,7 +87,7 @@ test 'navigation tests' => sub {
 
     @product_path = $product->path;
 
-    cmp_ok( scalar(@product_path), '==', 0, "Length of path for product" );
+    cmp_ok( scalar(@product_path), '==', 2, "Length of path for product" );
 
     @product_path = $product->path('country');
 


### PR DESCRIPTION
This closes #133 and provides a possible solution to #144.
