### PR TITLE
This experimental patch should make the Message's "uri" unique.

### DIFF
--- a/lib/Interchange6/Schema/Result/Message.pm
+++ b/lib/Interchange6/Schema/Result/Message.pm
@@ -68,7 +68,7 @@ The uri of the message data.
 
 =cut
 
-column uri => {
+unique_column uri => {
     data_type         => "varchar",
     is_nullable       => 1,
     size              => 255

--- a/t/lib/Test/Message.pm
+++ b/t/lib/Test/Message.pm
@@ -23,6 +23,32 @@ test 'simple message tests' => sub {
     my $author   = $self->users->find( { username => 'customer1' } );
     my $approver = $self->users->find( { username => 'admin1' } );
 
+    my $type = $schema->resultset('MessageType')->update_or_create({ name => 'static' });
+    lives_ok(sub {
+                 $schema->resultset('Message')->create({
+                                                        type => 'static',
+                                                        uri => '/blabla',
+                                                        format => 'html',
+                                                        content => '<em>test</em>',
+                                                        public => 1,
+                                                       })
+             }, "Created  static message");
+
+    lives_ok(sub {
+                 $schema->resultset('Message')->update_or_create({
+                                                                  type => 'static',
+                                                                  uri => '/blabla',
+                                                                  format => 'html',
+                                                                  content => '<em>test</em>',
+                                                                  public => 1,
+                                                                 })
+             }, "Created  static message");
+
+    $schema->resultset('Message')->find({ uri => '/blabla' })->delete;
+
+
+
+
     $data = {};
 
     cmp_ok( $rset_message->count, '==', 0, "We have zero messages" );


### PR DESCRIPTION
This in theory should make the update_or_create possible when the uri
is supplied.

Anyway, the overloading of "type" seems not to work and an exception
is raised.

The update_or_create failure happens even without the patch to the
Message class.